### PR TITLE
Support for namespaces (xmlns: and anything in custom attributes)

### DIFF
--- a/pkg/geojson2svg/geojson2svg.go
+++ b/pkg/geojson2svg/geojson2svg.go
@@ -77,7 +77,7 @@ func (svg *SVG) Draw(width, height float64, opts ...Option) string {
 	}
 
 	attributes := makeAttributes(svg.attributes)
-	return fmt.Sprintf(`<svg width="%f" height="%f"%s>%s</svg>`, width, height, attributes, content)
+	return fmt.Sprintf(`<svg xmlns="http://www.w3.org/2000/svg" width="%f" height="%f"%s>%s</svg>`, width, height, attributes, content)
 }
 
 // AddGeometry adds a geojson geometry to the svg.

--- a/pkg/geojson2svg/geojson2svg.go
+++ b/pkg/geojson2svg/geojson2svg.go
@@ -269,13 +269,21 @@ func trim(s fmt.Stringer) string {
 
 func makeAttributes(as map[string]string) string {
 	keys := make([]string, 0, len(as))
+	namespaces := make(map[string]bool)
 	for k := range as {
 		keys = append(keys, k)
+		ns := strings.Split(k, ":")
+		if len(ns) == 2 {
+			namespaces[ns[0]] = true
+		}
 	}
 	sort.Strings(keys)
 	res := bytes.NewBufferString("")
 	for _, k := range keys {
 		fmt.Fprintf(res, ` %s="%s"`, k, as[k])
+	}
+	for ns, _ := range namespaces {
+	    fmt.Fprintf(res, ` xmlns:%s="x-urn:namespace:%s"`, ns, ns)
 	}
 	return res.String()
 }


### PR DESCRIPTION
Hi, 

We're using `geojson2svg` over here:

https://github.com/whosonfirst/go-whosonfirst-svg

But the default output doesn't play nicely with Batik, because it is strict about namespaces:

https://github.com/straup/java-ws-raster/

Attached is the simplest/dumbest support for namespaces. It does not support the fully-qualified "{NAMESPACE}:PREFIX" syntax (yet).